### PR TITLE
fix: owlv2 device on processor

### DIFF
--- a/vision_agent_tools/tools/owlv2.py
+++ b/vision_agent_tools/tools/owlv2.py
@@ -56,6 +56,7 @@ class Owlv2(BaseTool):
         )
 
         self._model.to(self.device)
+        self._processor.to(self.device)
         self._model.eval()
 
     def __call__(

--- a/vision_agent_tools/tools/owlv2.py
+++ b/vision_agent_tools/tools/owlv2.py
@@ -56,7 +56,6 @@ class Owlv2(BaseTool):
         )
 
         self._model.to(self.device)
-        self._processor.to(self.device)
         self._model.eval()
 
     def __call__(
@@ -83,7 +82,9 @@ class Owlv2(BaseTool):
         """
         texts = [prompts]
         # Run model inference here
-        inputs = self._processor(text=texts, images=image, return_tensors="pt")
+        inputs = self._processor(text=texts, images=image, return_tensors="pt").to(
+            self.device
+        )
         # Forward pass
         with torch.no_grad():
             outputs = self._model(**inputs)


### PR DESCRIPTION
Description
---
The Owlv2 model is failing when loading the input into the model resulting in the following error:
`RuntimeError: Input type (torch.FloatTensor) and weight type (torch.cuda.FloatTensor) should be the same or input should be a MKLDNN tensor and weight is a dense tensor`

This PR fixes this error