### PR TITLE
Use quad rather than polygon

### DIFF
--- a/vision_agent_tools/tools/qr_reader.py
+++ b/vision_agent_tools/tools/qr_reader.py
@@ -20,7 +20,7 @@ class QRCodeDetection(BaseModel):
         description="A `Polygon` object representing the detected QR code's corner points"
     )
     bounding_box: BoundingBox = Field(
-        description="A `BoundingBox` object representing the bounding box coordinates of the detected QR code"
+        description="A `BoundingBox` object representing the axis-aligned bounding box coordinates of the detected QR code"
     )
     center: Point = Field(
         description="A `Point` object representing the center coordinates of the detected QR code"
@@ -66,9 +66,7 @@ class QRReader(BaseTool):
                 confidence=meta["confidence"],
                 text=text,
                 polygon=Polygon(
-                    points=[
-                        Point(x=point[0], y=point[1]) for point in meta["polygon_xy"]
-                    ]
+                    points=[Point(x=point[0], y=point[1]) for point in meta["quad_xy"]]
                 ),
                 bounding_box=BoundingBox(
                     x_min=meta["bbox_xyxy"][0],


### PR DESCRIPTION
Polygon has too many points - it's probably better to use `quad_xy` because that gives the four-corners polygon that segments the QR code, and that matches the bar code API as well