### PR TITLE
docs: match style among vision-agent repositories

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,8 +3,33 @@ site_name: Vision Agent Tools
 
 theme:
   name: "material"
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: teal
+      accent: amber
+      toggle:
+        icon: material/lightbulb
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: teal
+      accent: amber
+      toggle:
+        icon: material/lightbulb-outline
+        name: Switch to light mode
   features:
+    - search.suggest
+    - search.highlight
+    - content.tabs.link
+    - navigation.indexes
+    - content.tooltips
+    - navigation.path
+    - content.code.annotate
     - content.code.copy
+    - content.code.select
+  icon:
+    repo: fontawesome/brands/github-alt
 
 markdown_extensions:
   - admonition
@@ -23,6 +48,7 @@ markdown_extensions:
       permalink: "#"
 
 plugins:
+- search: null
 - mkdocstrings:
     default_handler: python
     handlers:


### PR DESCRIPTION
Similar style than vision-agent repository for documentation.

![Screenshot 2024-08-21 121801](https://github.com/user-attachments/assets/19c42b39-a84c-4502-bbee-3d99faa88be3)
