### PR TITLE
chore: test florence2sam2 tracking improvements

### DIFF
--- a/tests/models/test_florence2_sam2.py
+++ b/tests/models/test_florence2_sam2.py
@@ -39,9 +39,10 @@ def test_successful_florence2_sam2_video():
     tomatoes_image = np.array(
         Image.open("tests/tools/data/loca/tomatoes.jpg").convert("RGB"), dtype=np.uint8
     )
-    test_video = np.array(
-        [tomatoes_image, np.zeros(tomatoes_image.shape, dtype=np.uint8)]
-    )
+    img_size = tomatoes_image.size
+    np_test_img = np.array(tomatoes_image)
+    zeros = np.zeros((img_size[1], img_size[0], 3), dtype=np.uint8)
+    test_video = np.array(np_test_img, zeros)
 
     florence2_sam2 = Florence2SAM2()
 
@@ -51,20 +52,13 @@ def test_successful_florence2_sam2_video():
     assert len(results) == 2
     # The first frame should have 23 instances of the tomato class
     assert len(results[0]) == 23
-    assert len(results[1]) == 23
+    # The second frame should not have any tomato class since it is all zeros
+    assert len(results[1]) == 0
     # First frame
     for instance in results[0].values():
         assert isinstance(instance.mask, np.ndarray)
         assert instance.mask.shape == tomatoes_image.shape[:2]
         assert instance.label == "tomato"
-
-    # Second frame
-    for instance in results[1].values():
-        assert isinstance(instance.mask, np.ndarray)
-        assert instance.mask.shape == tomatoes_image.shape[:2]
-        assert instance.label == "tomato"
-        # All masks should de empty since it's a black frame
-        assert np.all(instance.mask == 0)
 
 
 def test_florence2_sam2_invalid_media():

--- a/tests/models/test_florence2_sam2.py
+++ b/tests/models/test_florence2_sam2.py
@@ -36,13 +36,12 @@ def test_successful_florence2_sam2_video():
     """
     This test verifies that Florence2SAM2 returns a valid iresponse when passed a video
     """
-    tomatoes_image = np.array(
-        Image.open("tests/tools/data/loca/tomatoes.jpg").convert("RGB"), dtype=np.uint8
-    )
+    tomatoes_image = Image.open("tests/tools/data/loca/tomatoes.jpg").convert("RGB")
     img_size = tomatoes_image.size
-    np_test_img = np.array(tomatoes_image)
+    np_test_img = np.array(tomatoes_image, dtype=np.uint8)
     zeros = np.zeros((img_size[1], img_size[0], 3), dtype=np.uint8)
-    test_video = np.array(np_test_img, zeros)
+
+    test_video = np.array([np_test_img, zeros])
 
     florence2_sam2 = Florence2SAM2()
 
@@ -57,7 +56,7 @@ def test_successful_florence2_sam2_video():
     # First frame
     for instance in results[0].values():
         assert isinstance(instance.mask, np.ndarray)
-        assert instance.mask.shape == tomatoes_image.shape[:2]
+        assert instance.mask.shape == np_test_img.shape[:2]
         assert instance.label == "tomato"
 
 

--- a/vision_agent_tools/models/florence2_sam2.py
+++ b/vision_agent_tools/models/florence2_sam2.py
@@ -184,13 +184,11 @@ class Florence2SAM2(BaseMLModel):
         video: VideoNumpy,
         chunk_length: int | None = 20,
         iou_threshold: float = 0.8,
-    ) -> tuple[dict[int, dict[int, ImageBboxAndMaskLabel]], dict[int, dict[int, ImageBboxAndMaskLabel]], dict[int, dict[int, ImageBboxAndMaskLabel]]]:
+    ) -> dict[int, dict[int, ImageBboxAndMaskLabel]]:
         video_shape = video.shape
         num_frames = video_shape[0]
         video_segments = {}
         objects_count = 0
-        sam2_preds: dict[int, dict[int, ImageBboxAndMaskLabel]] = {}
-        florence2_preds: dict[int, dict[int, ImageBboxAndMaskLabel]] = {}
         last_chunk_frame_pred: dict[int, ImageBboxAndMaskLabel] = {}
 
         if chunk_length is None:
@@ -200,20 +198,16 @@ class Florence2SAM2(BaseMLModel):
 
             for start_frame_idx in range(0, num_frames, chunk_length):
                 self.image_predictor.reset_predictor()
-                # fl_frame_idx = 0 if len(last_chunk_frame_pred.keys()) == 0 else start_frame_idx - 1
-                print("start_frame_idx: ", start_frame_idx)
                 objs = self._get_bbox_and_mask(
                     prompt,
                     Image.fromarray(video[start_frame_idx]).convert("RGB"),
                 )
-                florence2_preds[start_frame_idx] = objs
                 # Compare the IOU between the predicted label 'objs' and the 'last_chunk_frame_pred'
                 # and update the object prediction id, to match the previous id.
                 # Also add the new objects in case they didn't exist before.
                 updated_objs, objects_count = self._update_reference_predictions(
                     last_chunk_frame_pred, objs, objects_count, iou_threshold
                 )
-                print("objects_count: ", objects_count)
                 self.video_predictor.reset_state(inference_state)
 
                 # Add new label points to the video predictor coming from the FlorenceV2 object predictions
@@ -257,10 +251,9 @@ class Florence2SAM2(BaseMLModel):
                 )
                 # Save the last frame predictions to later update the newly found FlorenceV2 object ids
                 last_chunk_frame_pred = video_segments[index]
-                sam2_preds[index] = video_segments[index]
                 self.video_predictor.reset_state(inference_state)
 
-        return (video_segments, sam2_preds, florence2_preds)
+        return video_segments
 
     @validate_call(config={"arbitrary_types_allowed": True})
     @torch.inference_mode()


### PR DESCRIPTION
Description
---
* Previously, we were comparing Florencev2 predictions with the SAM2 predictions and on the cases that the IoU were high, we kept the Florence predictions and updated the prediction's annotation id.
* On this PR we change the approach to keep the SAM2 predictions for the cases were the IoU is high and only add the new annotation predictions coming from Florencev2 (the new objects that are not being tracked by SAM2 in the video propagation)
* Also, we filter out the SAM2 annotations that have prediction maks of only zero values.
* With these changes, we will appreciate on the videos below that we improve the tracking of objects, specially on those smaller objects that are more difficult to detect by the Florencev2 model.

Tests
---

Previous output

https://github.com/user-attachments/assets/1db94f05-8f4f-41a0-9dbd-49e65a075631

New output

https://github.com/user-attachments/assets/89a84c30-4d7e-4803-9afe-e9da5542cd5b
