### PR TITLE
feat: model pool support model with same class

### DIFF
--- a/tests/tools/test_shared_model_manager.py
+++ b/tests/tools/test_shared_model_manager.py
@@ -34,33 +34,30 @@ async def test_add_model(model_pool: SharedModelManager):
     assert model_id3 != model_id
 
 @pytest.mark.asyncio
-async def test_get_model_cpu(model_pool):
-    def model_creation_fn():
-        model = MockBaseModel()
-        model.to = MagicMock()
-        return model
+async def test_get_model_cpu(model_pool: SharedModelManager):
+    model = MockBaseModel()
+    model.to = MagicMock()
 
-    model_pool.add(model_creation_fn)
+    model_id = model_pool.add(model)
 
-    model_to_get = await model_pool.fetch_model(model_creation_fn.__name__)
+    model_to_get = await model_pool.fetch_model(model_id)
 
     assert model_to_get is not None
     assert model_to_get.to.call_count == 0  # No device change for CPU
 
 
 @pytest.mark.asyncio
-async def test_get_model_gpu(model_pool):
-    def model_creation_fn():
-        model = MockBaseModel()
-        model.to = MagicMock()
-        return model
+async def test_get_model_gpu(model_pool: SharedModelManager):
+    model = MockBaseModel()
+    model.to = MagicMock()
 
-    model_pool.add(model_creation_fn, device=Device.GPU)
+    model_id = model_pool.add(model, device=Device.GPU)
 
-    model_to_get = await model_pool.fetch_model(model_creation_fn.__name__)
+    model_to_get = await model_pool.fetch_model(model_id)
 
     assert model_to_get.to.call_count == 1
     model_to_get.to.assert_called_once_with(Device.GPU)  # Verify to was called with GPU
+
 
 
 @pytest.mark.asyncio

--- a/tests/tools/test_shared_model_manager.py
+++ b/tests/tools/test_shared_model_manager.py
@@ -16,20 +16,22 @@ class MockBaseModel(AsyncMock, BaseTool):
 
 
 @pytest.mark.asyncio
-async def test_add_model(model_pool):
-    def model_creation_fn():
-        return MockBaseModel()
+async def test_add_model(model_pool: SharedModelManager):
 
-    model_pool.add(model_creation_fn)
-
+    test_model = MockBaseModel()
+    model_id = model_pool.add(test_model)
     assert len(model_pool.models) == 1
-    assert model_creation_fn.__name__ in model_pool.models
+    assert model_id in model_pool.models
 
-    model_pool.add(model_creation_fn)  # Duplicate addition
-
+    model_id2 = model_pool.add(test_model)  # Duplicate addition
     assert len(model_pool.models) == 1
-    assert model_creation_fn.__name__ in model_pool.models
+    assert model_id2 in model_pool.models
+    assert model_id2 == model_id
 
+    model_id3 = model_pool.add(MockBaseModel())  # Not duplicate addition
+    assert len(model_pool.models) == 2
+    assert model_id3 in model_pool.models
+    assert model_id3 != model_id
 
 @pytest.mark.asyncio
 async def test_get_model_cpu(model_pool):
@@ -93,4 +95,4 @@ async def test_swap_model_in_gpu(model_pool):
     assert model2_to_get is not None
     assert model_pool._get_current_gpu_model() == model_creation_fn_b.__name__
 
-    # Also 
+    # Also

--- a/tests/tools/test_shared_model_manager.py
+++ b/tests/tools/test_shared_model_manager.py
@@ -67,29 +67,23 @@ async def test_get_model_not_found(model_pool):
 
 
 @pytest.mark.asyncio
-async def test_swap_model_in_gpu(model_pool):
+async def test_swap_model_in_gpu(model_pool: SharedModelManager):
 
-    def model_creation_fn_a():
-        model = MockBaseModel()
-        model.to = MagicMock()
-        return model
+    model_a = MockBaseModel()
+    model_a.to = MagicMock()
 
-    def model_creation_fn_b():
-        model = MockBaseModel()
-        model.to = MagicMock()
-        return model
+    model_b = MockBaseModel()
+    model_b.to = MagicMock()
 
-    model_pool.add(model_creation_fn_a, device=Device.GPU)
-    model_pool.add(model_creation_fn_b, device=Device.GPU)
+    model_a_id = model_pool.add(model_a, device=Device.GPU)
+    model_b_id = model_pool.add(model_b, device=Device.GPU)
 
     # Get Model1 first, should use GPU
-    model1_to_get = await model_pool.fetch_model(model_creation_fn_a.__name__)
+    model1_to_get = await model_pool.fetch_model(model_a_id)
     assert model1_to_get is not None
-    assert model_pool._get_current_gpu_model() == model_creation_fn_a.__name__
+    assert model_pool._get_current_gpu_model() == model_a_id
 
     # Get Model2, should move Model1 to CPU and use GPU
-    model2_to_get = await model_pool.fetch_model(model_creation_fn_b.__name__)
+    model2_to_get = await model_pool.fetch_model(model_b_id)
     assert model2_to_get is not None
-    assert model_pool._get_current_gpu_model() == model_creation_fn_b.__name__
-
-    # Also
+    assert model_pool._get_current_gpu_model() == model_b_id

--- a/vision_agent_tools/shared_types.py
+++ b/vision_agent_tools/shared_types.py
@@ -34,7 +34,7 @@ class BaseTool:
     Tools are responsible for interfacing with one or more ML models to perform specific tasks.
     """
 
-    def __init__(self, model: str):
+    def __init__(self, model: str, ):
         self.model = model
 
     def __call__(self):

--- a/vision_agent_tools/tools/shared_model_manager.py
+++ b/vision_agent_tools/tools/shared_model_manager.py
@@ -56,12 +56,12 @@ class SharedModelManager:
             Any: The retrieved model instance.
         """
 
-        if class_name not in self.models:
-            raise ValueError(f"Model '{class_name}' not found in the pool.")
+        if model_id not in self.models:
+            raise ValueError(f"Model '{model_id}' not found in the pool.")
 
-        model = self.models[class_name]
-        lock = self.model_locks[class_name]
-        device = self.devices[class_name]
+        model = self.models[model_id]
+        lock = self.model_locks[model_id]
+        device = self.devices[model_id]
 
         async def get_model_with_lock() -> Any:
             async with lock:
@@ -74,7 +74,7 @@ class SharedModelManager:
                             await self._move_to_cpu(exisitng)
 
                         # Update current GPU model
-                        self.current_gpu_model = class_name
+                        self.current_gpu_model = model_id
                         model.to(Device.GPU)
                 return model
 

--- a/vision_agent_tools/tools/text_to_object_detection.py
+++ b/vision_agent_tools/tools/text_to_object_detection.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import List, Optional
+from typing import List
 from typing import Annotated
 from annotated_types import Len
 
@@ -66,6 +66,14 @@ class TextToObjectDetection(BaseTool):
             pass  # Note we don't need model config for FlorenceV2
         else:
             raise ValueError(f"Model is not supported: '{model}'")
+
+        self.model_class = get_model_class(model_name=model)
+        model_instance = self.model_class()
+        if model == TextToObjectDetectionModel.OWLV2:
+            super().__init__(model=model_instance(self.owlv2_config))
+        elif model == TextToObjectDetectionModel.FLORENCEV2:
+            super().__init__(model=model_instance())
+
 
     def _convert_florencev2_res(self, res: FlorenceV2ODRes) -> list[ODResponseData]:
         """

--- a/vision_agent_tools/tools/text_to_object_detection.py
+++ b/vision_agent_tools/tools/text_to_object_detection.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import List
+from typing import List, Optional
 from typing import Annotated
 from annotated_types import Len
 
@@ -66,13 +66,6 @@ class TextToObjectDetection(BaseTool):
             pass  # Note we don't need model config for FlorenceV2
         else:
             raise ValueError(f"Model is not supported: '{model}'")
-
-        self.model_class = get_model_class(model_name=model)
-        model_instance = self.model_class()
-        if model == TextToObjectDetectionModel.OWLV2:
-            super().__init__(model=model_instance(self.owlv2_config))
-        elif model == TextToObjectDetectionModel.FLORENCEV2:
-            super().__init__(model=model_instance())
 
     def _convert_florencev2_res(self, res: FlorenceV2ODRes) -> list[ODResponseData]:
         """


### PR DESCRIPTION
Right now the model does not support adding model instances under the same class. However we do need to switch among  instances instead of class, because:

1. The same Basetool can have different model config
2. The same Basetool can event have more than one models , e.g. TextToObjectDetection 

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/5bfc17d1-25ec-49b7-a017-af38591744c0">
