### PR TITLE
refactor: batch support for owlv2 in video

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ install:
 	bash ./scripts/install.sh
 
 test:
-	$(POETRY) run pytest -x -vvvv tests
+	$(POETRY) run pytest -x -vvvv --log-cli-level=INFO tests
 
 serve/docs:
 	# Start the documentation server

--- a/tests/models/test_owlv2.py
+++ b/tests/models/test_owlv2.py
@@ -1,18 +1,7 @@
-import gc
-
 import cv2
-import pytest
-import torch
 from PIL import Image
 
 from vision_agent_tools.models.owlv2 import Owlv2, OWLV2Config
-
-
-@pytest.fixture(autouse=True)
-def clear_gpu_memory():
-    yield
-    torch.cuda.empty_cache()
-    gc.collect()
 
 
 def test_successful_image_detection():

--- a/tests/models/test_owlv2.py
+++ b/tests/models/test_owlv2.py
@@ -34,7 +34,7 @@ def test_successful_video_detection():
         frames.append(frame)
     cap.release()
 
-    owlv2 = Owlv2()
+    owlv2 = Owlv2(model_config=OWLV2Config(max_batch_size=2))
     results = owlv2(prompts=prompts, video=frames)
     assert len(results) > 0
 

--- a/tests/models/test_owlv2.py
+++ b/tests/models/test_owlv2.py
@@ -34,6 +34,10 @@ def test_successful_video_detection():
         frames.append(frame)
     cap.release()
 
+    # Set the batch size to 2 for testing in GitHub Actions to prevent
+    # exceeding GPU memory limits.
+    # Larger batch sizes may cause memory allocation errors due to limited GPU
+    # resources in the CI environment.
     owlv2 = Owlv2(model_config=OWLV2Config(max_batch_size=2))
     results = owlv2(prompts=prompts, video=frames)
     assert len(results) > 0

--- a/tests/models/test_owlv2.py
+++ b/tests/models/test_owlv2.py
@@ -1,7 +1,18 @@
+import gc
+
 import cv2
+import pytest
+import torch
 from PIL import Image
 
 from vision_agent_tools.models.owlv2 import Owlv2, OWLV2Config
+
+
+@pytest.fixture(autouse=True)
+def clear_gpu_memory():
+    yield
+    torch.cuda.empty_cache()
+    gc.collect()
 
 
 def test_successful_image_detection():

--- a/vision_agent_tools/models/florencev2.py
+++ b/vision_agent_tools/models/florencev2.py
@@ -73,7 +73,7 @@ class Florencev2(BaseMLModel):
             PROCESSOR_NAME, trust_remote_code=True
         )
 
-        if device == None:
+        if device is None:
             self.device = (
                 "cuda"
                 if torch.cuda.is_available()
@@ -94,6 +94,7 @@ class Florencev2(BaseMLModel):
         images: List[Image.Image] | None = None,
         video: VideoNumpy | None = None,
         prompt: str | None = "",
+        batch_size: int = 3,
     ) -> Any:
         """
         Performs inference on the Florence-2 model based on the provided task, images, video (optional), and prompt.
@@ -151,7 +152,19 @@ class Florencev2(BaseMLModel):
             text_input = str(task.value) + prompt
             text_inputs = [text_input] * num_images
 
-            return self._batch_image_call(text_inputs, images_list, task)
+            results = []
+
+            # Split images and text_inputs into batches
+            for i in range(0, num_images, batch_size):
+                batch_images = images_list[i : i + batch_size]
+                batch_text_inputs = text_inputs[i : i + batch_size]
+                batch_results = self._batch_image_call(
+                    batch_text_inputs, batch_images, task
+                )
+                results.extend(batch_results)
+
+            return results
+
         elif video is not None:
             # Process video frames
             images_list = self._process_video(video)
@@ -161,7 +174,18 @@ class Florencev2(BaseMLModel):
             text_input = str(task.value) + prompt
             text_inputs = [text_input] * num_images
 
-            return self._batch_image_call(text_inputs, images_list, task)
+            results = []
+
+            # Split frames and text_inputs into batches
+            for i in range(0, num_images, batch_size):
+                batch_images = images_list[i : i + batch_size]
+                batch_text_inputs = text_inputs[i : i + batch_size]
+                batch_results = self._batch_image_call(
+                    batch_text_inputs, batch_images, task
+                )
+                results.extend(batch_results)
+
+            return results
 
     def _batch_image_call(
         self,

--- a/vision_agent_tools/models/florencev2.py
+++ b/vision_agent_tools/models/florencev2.py
@@ -94,7 +94,7 @@ class Florencev2(BaseMLModel):
         images: List[Image.Image] | None = None,
         video: VideoNumpy | None = None,
         prompt: str | None = "",
-        batch_size: int = 3,
+        batch_size: int = 5,
     ) -> Any:
         """
         Performs inference on the Florence-2 model based on the provided task, images, video (optional), and prompt.

--- a/vision_agent_tools/models/owlv2.py
+++ b/vision_agent_tools/models/owlv2.py
@@ -153,6 +153,7 @@ class Owlv2(BaseMLModel):
             prompts (list[str]): A list of prompts to be used during inference.
                                   Currently, only one prompt is supported (list length of 1).
             video (Optional[VideoNumpy]: The input video for object detection.
+            batch_size (Optional[int]): Number of frames to process in a single batch. Defaults to model's max_batch_size.
 
         Returns:
             Optional[list[Owlv2InferenceData]]: A list of `Owlv2InferenceData` objects containing the predicted
@@ -160,6 +161,8 @@ class Owlv2(BaseMLModel):
                                                with confidence exceeding the threshold. Returns None if no objects
                                                are detected above the confidence threshold.
         """
+        if batch_size is None:
+            batch_size = self.model_config.max_batch_size
 
         if image is None and video is None:
             raise ValueError("Either 'image' or 'video' must be provided.")

--- a/vision_agent_tools/models/owlv2.py
+++ b/vision_agent_tools/models/owlv2.py
@@ -1,3 +1,5 @@
+import torch
+import torch.profiler
 import logging
 import time
 from typing import List, Optional, Tuple, Union
@@ -8,7 +10,6 @@ from PIL import Image
 from pydantic import BaseModel, Field
 from transformers import Owlv2ForObjectDetection, Owlv2Processor
 from transformers.image_transforms import center_to_corners_format
-from transformers.models.owlv2.image_processing_owlv2 import box_iou
 from transformers.utils import TensorType
 
 from vision_agent_tools.shared_types import BaseMLModel, Device, VideoNumpy
@@ -81,16 +82,26 @@ class Owlv2(BaseMLModel):
 
     def __run_inference(self, images, prompts, confidence, nms_threshold):
         # Prepare texts for each image
-        texts = [prompts for _ in images]  # List of lists of prompts
+        prep_start = time.time()
+        texts = [prompts] * len(images)  # List of lists of prompts
 
         # Run model inference here
-        inputs = self._processor(text=texts, images=images, return_tensors="pt").to(
-            self.model_config.device
-        )
+        inputs = self._processor(
+            text=texts, images=images, return_tensors="pt", padding=True
+        ).to(self.model_config.device)
+        prep_end = time.time()
+        logger.info(f"Input preparation time: {prep_end - prep_start:.4f} seconds")
+
+        logger.info(f"Input pixel_values shape: {inputs['pixel_values'].shape}")
+        logger.info(f"Input input_ids shape: {inputs['input_ids'].shape}")
+        logger.info(f"Input attention_mask shape: {inputs['attention_mask'].shape}")
 
         # Forward pass
+        infer_start = time.time()
         with torch.autocast(device_type=self.model_config.device.value):
             outputs = self._model(**inputs)
+        infer_end = time.time()
+        logger.info(f"Model inference time: {infer_end - infer_start:.4f} seconds")
 
         # Prepare target_sizes
         target_sizes = torch.tensor(
@@ -98,12 +109,15 @@ class Owlv2(BaseMLModel):
         )
 
         # Convert outputs (bounding boxes and class logits) to the final predictions type
+        post_start = time.time()
         results = self._processor.post_process_object_detection_with_nms(
             outputs=outputs,
             threshold=confidence,
             nms_threshold=nms_threshold,
             target_sizes=target_sizes,
         )
+        post_end = time.time()
+        logger.info(f"Post-processing time: {post_end - post_start:.4f} seconds")
 
         inferences_batch = []
 
@@ -123,6 +137,9 @@ class Owlv2(BaseMLModel):
                     )
                 )
             inferences_batch.append(inferences)
+
+        total_time = post_end - prep_start
+        logger.info(f"Total inference time: {total_time:.4f} seconds")
 
         return inferences_batch
 
@@ -196,27 +213,45 @@ class Owlv2(BaseMLModel):
             )
             inferences = []
 
+            start_time = time.time()
+
             # Split images into batches
+            # with torch.profiler.profile(
+            #         activities=[
+            #             torch.profiler.ProfilerActivity.CPU,
+            #             torch.profiler.ProfilerActivity.CUDA,
+            #         ],
+            #         record_shapes=True,
+            #         profile_memory=True,
+            #         with_stack=True,
+            #     ) as prof:
+
             for batch_index, i in enumerate(range(0, total_frames, batch_size)):
                 batch_images = images[i : i + batch_size]
-                logger.info(
+                logger.debug(
                     f"Processing batch {batch_index + 1}/{(total_frames + batch_size - 1) // batch_size} with {len(batch_images)} frames."
                 )
-                start_time = time.time()
+                batch_start_time = time.time()
+
                 batch_inferences = self.__run_inference(
                     images=batch_images,
                     prompts=prompts,
                     confidence=self.model_config.confidence,
                     nms_threshold=self.model_config.nms_threshold,
                 )
+
                 end_time = time.time()
-                batch_time = end_time - start_time
-                logger.info(
+                batch_time = end_time - batch_start_time
+                logger.debug(
                     f"Processed batch {batch_index + 1} in {batch_time:.2f} seconds."
                 )
                 inferences.extend(batch_inferences)
+            # logger.info(prof.key_averages().table(sort_by="cuda_time_total", row_limit=20))
 
-            logger.info(f"Completed processing of {total_frames} frames.")
+            total_time = time.time() - start_time
+            logger.info(
+                f"Completed processing of {total_frames} frames in {total_time}s."
+            )
             return inferences  # Return a list of inference data for each frame
 
     def to(self, device: Device):
@@ -224,6 +259,63 @@ class Owlv2(BaseMLModel):
 
 
 class Owlv2ProcessorWithNMS(Owlv2Processor):
+    def nms(self, boxes, scores, iou_threshold):
+        """
+        Performs Non-Maximum Suppression (NMS) on the bounding boxes.
+
+        Args:
+            boxes (Tensor[N, 4]): Bounding boxes in (x1, y1, x2, y2) format.
+            scores (Tensor[N]): Scores for each bounding box.
+            iou_threshold (float): IoU threshold for suppression.
+
+        Returns:
+            keep (Tensor): Indices of bounding boxes to keep.
+        """
+        # Ensure boxes and scores are tensors
+        boxes = boxes.to(device=boxes.device)
+        scores = scores.to(device=boxes.device)
+
+        # Compute areas of boxes
+        x1 = boxes[:, 0]  # xmin
+        y1 = boxes[:, 1]  # ymin
+        x2 = boxes[:, 2]  # xmax
+        y2 = boxes[:, 3]  # ymax
+
+        areas = (x2 - x1) * (y2 - y1)
+
+        # Sort the detections by score in descending order
+        order = scores.argsort(descending=True)
+
+        keep = []
+
+        while order.numel() > 0:
+            idx_self = order[0].item()
+            keep.append(idx_self)
+
+            if order.numel() == 1:
+                break
+
+            idx_other = order[1:]
+
+            # Compute IoU between the highest-scoring box and the rest
+            xx1 = torch.max(x1[idx_self], x1[idx_other])
+            yy1 = torch.max(y1[idx_self], y1[idx_other])
+            xx2 = torch.min(x2[idx_self], x2[idx_other])
+            yy2 = torch.min(y2[idx_self], y2[idx_other])
+
+            inter_w = (xx2 - xx1).clamp(min=0)
+            inter_h = (yy2 - yy1).clamp(min=0)
+            inter_area = inter_w * inter_h
+
+            union_area = areas[idx_self] + areas[idx_other] - inter_area
+            iou = inter_area / union_area
+
+            # Keep boxes with IoU less than the threshold
+            mask = iou <= iou_threshold
+            order = order[1:][mask]
+
+        return torch.tensor(keep, device=boxes.device)
+
     def post_process_object_detection_with_nms(
         self,
         outputs,
@@ -231,64 +323,49 @@ class Owlv2ProcessorWithNMS(Owlv2Processor):
         nms_threshold: float = 0.3,
         target_sizes: Union[TensorType, List[Tuple]] = None,
     ):
-        """
-        Converts the raw output of [`OwlViTForObjectDetection`] into final bounding boxes in (top_left_x, top_left_y,
-        bottom_right_x, bottom_right_y) format.
-
-        Args:
-            outputs ([`OwlViTObjectDetectionOutput`]):
-                Raw outputs of the model.
-            threshold (`float`, *optional*):
-                Score threshold to keep object detection predictions.
-            nms_threshold (`float`, *optional*):
-                IoU threshold to filter overlapping objects the raw detections.
-            target_sizes (`torch.Tensor` or `List[Tuple[int, int]]`, *optional*):
-                Tensor of shape `(batch_size, 2)` or list of tuples (`Tuple[int, int]`) containing the target size
-                `(height, width)` of each image in the batch. If unset, predictions will not be resized.
-        Returns:
-            `List[Dict]`: A list of dictionaries, each dictionary containing the scores, labels and boxes for an image
-            in the batch as predicted by the model.
-        """
         logits, boxes = outputs.logits, outputs.pred_boxes
 
-        if target_sizes is not None:
-            if isinstance(target_sizes, list):
-                img_h = torch.Tensor([i[0] for i in target_sizes]).to(boxes.device)
-                img_w = torch.Tensor([i[1] for i in target_sizes]).to(boxes.device)
-            else:
-                img_h, img_w = target_sizes.unbind(1)
-
-        # Get the max logits and corresponding labels
+        # Compute probabilities and labels
         probs = torch.max(logits, dim=-1)
         scores = torch.sigmoid(probs.values)
         labels = probs.indices
 
-        # Convert boxes from center format to corner format ([x0, y0, x1, y1])
+        # Convert boxes from center format to corner format
         boxes = center_to_corners_format(boxes)
-
-        # Apply non-maximum suppression (NMS)
-        if nms_threshold < 1.0:
-            for idx in range(boxes.shape[0]):
-                for i in torch.argsort(-scores[idx]):
-                    if not scores[idx][i]:
-                        continue
-                    ious = box_iou(boxes[idx][i, :].unsqueeze(0), boxes[idx])[0][0]
-                    ious[i] = -1.0  # Mask self-IoU.
-                    scores[idx][ious > nms_threshold] = 0.0
 
         # Scale boxes to absolute coordinates
         if target_sizes is not None:
-            scale_fct = torch.stack([img_w, img_h, img_w, img_h], dim=1).to(
-                boxes.device
-            )
-            boxes = boxes * scale_fct[:, None, :]
+            if isinstance(target_sizes, list):
+                target_sizes = torch.tensor(target_sizes, device=boxes.device)
+            img_h, img_w = target_sizes.unbind(1)
+            scale_fct = torch.stack([img_w, img_h, img_w, img_h], dim=1)[:, None, :]
+            boxes = boxes * scale_fct
 
         results = []
-        for score, label, box in zip(scores, labels, boxes):
+        batch_size = logits.shape[0]
+        for idx in range(batch_size):
+            score = scores[idx]
+            label = labels[idx]
+            box = boxes[idx]
+
+            # Apply confidence threshold
             valid_mask = score > threshold
             score = score[valid_mask]
             label = label[valid_mask]
             box = box[valid_mask]
+
+            if box.numel() == 0:
+                results.append({"scores": score, "labels": label, "boxes": box})
+                continue
+
+            # Apply NMS per image
+            nms_start = time.time()
+            keep = self.nms(box, score, nms_threshold)
+            score = score[keep]
+            label = label[keep]
+            box = box[keep]
+            nms_end = time.time()
+            logger.info(f"NMS time: {nms_end - nms_start:.4f} second")
 
             results.append({"scores": score, "labels": label, "boxes": box})
 

--- a/vision_agent_tools/models/owlv2.py
+++ b/vision_agent_tools/models/owlv2.py
@@ -151,7 +151,7 @@ class Owlv2(BaseMLModel):
         prompts: list[str],
         image: Image.Image | None = None,
         video: VideoNumpy[np.uint8] | None = None,
-        batch_size: int = 3,
+        batch_size: int | None = None,
     ) -> list[list[Owlv2InferenceData]]:
         """
         Performs object detection on an image using the Owlv2 model.


### PR DESCRIPTION
# Add Batch Processing to Owlv2 and Florencev2

## Owlv2 Model
- Added a `max_batch_size` attribute to `OWLV2Config`.
- Updated the `__call__` method to accept an optional batch_size parameter.
- Modified the `__run_inference` method to process batches of images.
- Adjusted video processing to handle frames in batches, improving memory efficiency.
- Added logging statements to provide detailed information about the batch processing.
- Removed unnecessary aspect ratio adjustments in `post_process_object_detection_with_nms`, which were causing errors due to ambiguous tensor comparisons, this was identified as part of introducing batch processing.
- Improved the scaling of bounding boxes from normalized coordinates to absolute pixel coordinates using direct scaling with image dimensions.
- In `test_owlv2.py`, set `max_batch_size` to `2` in the test configuration to prevent exceeding GPU memory limits in the GitHub Actions CI environment.
