### PR TITLE
feat: filter invalid bounding boxes

### DIFF
--- a/tests/helpers/test_filters.py
+++ b/tests/helpers/test_filters.py
@@ -242,3 +242,27 @@ def test_filter_invalid_bboxes_mixed_valid_invalid():
         "bboxes": [[10, 20, 30, 40], [50, 60, 70, 80]],
         "labels": ["sheep"],
     }
+
+
+def test_filter_invalid_bboxes():
+    predictions_list = [
+        {"bboxes": [[10, 20, 30, 40], [50, 60, 70, 80]], "labels": ["sheep", "sheep"]},
+        {"bboxes": [[-10, 20, 30, 40], [50, 60, 70, 80]], "labels": ["sheep", "sheep"]},
+        {"bboxes": [[10, 20, 110, 40], [50, 60, 70, 80]], "labels": ["sheep", "sheep"]},
+        {"bboxes": [[10, 20, 30, 40], [50, 60, 40, 70]], "labels": ["sheep", "sheep"]},
+        {"bboxes": [[10, 20, 30, 40], [50, 60, 70, 60]], "labels": ["sheep", "sheep"]},
+    ]
+
+    image_size = (100, 100)
+
+    expected_results = [
+        {"bboxes": [[10, 20, 30, 40], [50, 60, 70, 80]], "labels": ["sheep", "sheep"]},
+        {"bboxes": [[50, 60, 70, 80]], "labels": ["sheep"]},
+        {"bboxes": [[50, 60, 70, 80]], "labels": ["sheep"]},
+        {"bboxes": [[10, 20, 30, 40]], "labels": ["sheep"]},
+        {"bboxes": [[10, 20, 30, 40]], "labels": ["sheep"]},
+    ]
+
+    for idx, prediction in enumerate(predictions_list):
+        results = filter_bbox_predictions(prediction, image_size)
+        assert results == expected_results[idx]

--- a/tests/helpers/test_filters.py
+++ b/tests/helpers/test_filters.py
@@ -211,7 +211,7 @@ def test_filter_wrong_order():
     image_size = (835, 453)
 
     results = filter_bbox_predictions(predictions, image_size)
-    assert results == {"bboxes": [[50, 60, 70, 0]], "labels": ["sheep"]}
+    assert results == {"bboxes": [[50, 60, 70, 80]], "labels": ["sheep"]}
 
 
 def test_filter_invalid_bboxes_negative_coords():

--- a/tests/helpers/test_filters.py
+++ b/tests/helpers/test_filters.py
@@ -1,4 +1,7 @@
-from vision_agent_tools.helpers.filters import filter_bbox_predictions
+from vision_agent_tools.helpers.filters import (
+    filter_bbox_predictions,
+    _filter_invalid_bboxes,
+)
 
 
 def test_filter_bbox_predictions_remove_big_box():
@@ -190,3 +193,42 @@ def test_filter_bbox_predictions():
             "sheep",
         ],
     }
+
+
+def test_filter_valid_bboxes():
+    predictions = {"bboxes": [[10, 20, 30, 40], [50, 60, 70, 80]]}
+    image_size = (100, 100)
+
+    invalid_bboxes = _filter_invalid_bboxes(predictions, image_size)
+    assert invalid_bboxes == []
+
+
+def test_filter_invalid_bboxes_negative_coords():
+    predictions = {"bboxes": [[-10, 20, 30, 40], [50, 60, 70, 80]]}
+    image_size = (100, 100)
+
+    invalid_bboxes = _filter_invalid_bboxes(predictions, image_size)
+    assert invalid_bboxes == [[-10, 20, 30, 40]]
+
+
+def test_filter_invalid_bboxes_out_of_bounds():
+    predictions = {"bboxes": [[10, 20, 110, 40], [50, 60, 70, 80]]}
+    image_size = (100, 100)
+
+    invalid_bboxes = _filter_invalid_bboxes(predictions, image_size)
+    assert invalid_bboxes == [[10, 20, 110, 40]]
+
+
+def test_filter_invalid_bboxes_mixed_valid_invalid():
+    predictions = {
+        "bboxes": [
+            [10, 20, 30, 40],
+            [-10, 20, 30, 40],
+            [50, 60, 70, 80],
+            [110, 20, 120, 40],
+        ]
+    }
+    image_size = (100, 100)
+
+    invalid_bboxes = _filter_invalid_bboxes(predictions, image_size)
+    assert invalid_bboxes == [[-10, 20, 30, 40], [110, 20, 120, 40]]

--- a/tests/helpers/test_filters.py
+++ b/tests/helpers/test_filters.py
@@ -1,7 +1,4 @@
-from vision_agent_tools.helpers.filters import (
-    filter_bbox_predictions,
-    _filter_invalid_bboxes,
-)
+from vision_agent_tools.helpers.filters import filter_bbox_predictions
 
 
 def test_filter_bbox_predictions_remove_big_box():
@@ -196,27 +193,36 @@ def test_filter_bbox_predictions():
 
 
 def test_filter_valid_bboxes():
-    predictions = {"bboxes": [[10, 20, 30, 40], [50, 60, 70, 80]]}
+    predictions = {
+        "bboxes": [[10, 20, 30, 40], [50, 60, 70, 80]],
+        "labels": ["sheep", "sheep"],
+    }
     image_size = (100, 100)
 
-    invalid_bboxes = _filter_invalid_bboxes(predictions, image_size)
-    assert invalid_bboxes == []
+    results = filter_bbox_predictions(predictions, image_size)
+    assert results == predictions
 
 
 def test_filter_invalid_bboxes_negative_coords():
-    predictions = {"bboxes": [[-10, 20, 30, 40], [50, 60, 70, 80]]}
+    predictions = {
+        "bboxes": [[-10, 20, 30, 40], [50, 60, 70, 80]],
+        "labels": ["sheep", "sheep"],
+    }
     image_size = (100, 100)
 
-    invalid_bboxes = _filter_invalid_bboxes(predictions, image_size)
-    assert invalid_bboxes == [[-10, 20, 30, 40]]
+    results = filter_bbox_predictions(predictions, image_size)
+    assert results == {"bboxes": [[50, 60, 70, 80]], "labels": ["sheep"]}
 
 
 def test_filter_invalid_bboxes_out_of_bounds():
-    predictions = {"bboxes": [[10, 20, 110, 40], [50, 60, 70, 80]]}
+    predictions = {
+        "bboxes": [[10, 20, 110, 40], [50, 60, 70, 80]],
+        "labels": ["sheep", "sheep"],
+    }
     image_size = (100, 100)
 
-    invalid_bboxes = _filter_invalid_bboxes(predictions, image_size)
-    assert invalid_bboxes == [[10, 20, 110, 40]]
+    results = filter_bbox_predictions(predictions, image_size)
+    assert results == {"bboxes": [[50, 60, 70, 80]], "labels": ["sheep"]}
 
 
 def test_filter_invalid_bboxes_mixed_valid_invalid():
@@ -226,9 +232,13 @@ def test_filter_invalid_bboxes_mixed_valid_invalid():
             [-10, 20, 30, 40],
             [50, 60, 70, 80],
             [110, 20, 120, 40],
-        ]
+        ],
+        "labels": ["sheep", "sheep"],
     }
     image_size = (100, 100)
 
-    invalid_bboxes = _filter_invalid_bboxes(predictions, image_size)
-    assert invalid_bboxes == [[-10, 20, 30, 40], [110, 20, 120, 40]]
+    results = filter_bbox_predictions(predictions, image_size)
+    assert results == {
+        "bboxes": [[10, 20, 30, 40], [50, 60, 70, 80]],
+        "labels": ["sheep"],
+    }

--- a/tests/helpers/test_filters.py
+++ b/tests/helpers/test_filters.py
@@ -203,6 +203,17 @@ def test_filter_valid_bboxes():
     assert results == predictions
 
 
+def test_filter_wrong_order():
+    predictions = {
+        "bboxes": [[326.0, 362.6, 225.8, 262.9], [50, 60, 70, 80]],
+        "labels": ["sheep", "sheep"],
+    }
+    image_size = (835, 453)
+
+    results = filter_bbox_predictions(predictions, image_size)
+    assert results == {"bboxes": [[50, 60, 70, 0]], "labels": ["sheep"]}
+
+
 def test_filter_invalid_bboxes_negative_coords():
     predictions = {
         "bboxes": [[-10, 20, 30, 40], [50, 60, 70, 80]],

--- a/tests/models/test_owlv2.py
+++ b/tests/models/test_owlv2.py
@@ -43,8 +43,8 @@ def test_owlv2_removing_extra_bbox(shared_model):
 
     assert len(response) == 1
     item = response[0]
-    assert len(item["bboxes"]) == 42
-    assert len([label == "egg" for label in item["labels"]]) == 42
+    assert len(item["bboxes"]) == 40
+    assert len([label == "egg" for label in item["labels"]]) == 40
 
 
 def test_owlv2_image_with_nms(shared_model):

--- a/vision_agent_tools/helpers/filters.py
+++ b/vision_agent_tools/helpers/filters.py
@@ -214,7 +214,7 @@ def _filter_invalid_bboxes(
 
     invalid_bboxes = []
 
-    for bbox in zip(predictions[bboxes_key]):
+    for bbox in predictions[bboxes_key]:
         x1, y1, x2, y2 = bbox
         if not (0 <= x1 < x2 <= width and 0 <= y1 < y2 <= height):
             invalid_bboxes.append(bbox)

--- a/vision_agent_tools/helpers/filters.py
+++ b/vision_agent_tools/helpers/filters.py
@@ -216,7 +216,7 @@ def _filter_invalid_bboxes(
     invalid_indices = []
 
     for idx, bbox in enumerate(predictions[bboxes_key]):
-        bbox_ceil = [math.ceil(num) for num in bbox]
+        bbox_ceil = [math.floor(num) for num in bbox]
         x1, y1, x2, y2 = bbox_ceil
         if not (0 <= x1 < x2 <= width and 0 <= y1 < y2 <= height):
             invalid_indices.append(idx)

--- a/vision_agent_tools/helpers/filters.py
+++ b/vision_agent_tools/helpers/filters.py
@@ -1,5 +1,4 @@
 import logging
-import math
 from typing import Any
 
 from vision_agent_tools.models.utils import calculate_bbox_iou
@@ -216,8 +215,7 @@ def _filter_invalid_bboxes(
     invalid_indices = []
 
     for idx, bbox in enumerate(predictions[bboxes_key]):
-        bbox_ceil = [math.floor(num) for num in bbox]
-        x1, y1, x2, y2 = bbox_ceil
+        x1, y1, x2, y2 = bbox
         if not (0 <= x1 < x2 <= width and 0 <= y1 < y2 <= height):
             invalid_indices.append(idx)
             _LOGGER.warning(f"Removing invalid bbox {bbox}")

--- a/vision_agent_tools/helpers/filters.py
+++ b/vision_agent_tools/helpers/filters.py
@@ -214,10 +214,10 @@ def _filter_invalid_bboxes(
 
     invalid_bboxes = []
 
-    for bbox in predictions[bboxes_key]:
+    for idx, bbox in enumerate(predictions[bboxes_key]):
         x1, y1, x2, y2 = bbox
         if not (0 <= x1 < x2 <= width and 0 <= y1 < y2 <= height):
-            invalid_bboxes.append(bbox)
+            invalid_bboxes.append(idx)
             _LOGGER.warning(f"Removing invalid bbox {bbox}")
 
     return invalid_bboxes

--- a/vision_agent_tools/helpers/filters.py
+++ b/vision_agent_tools/helpers/filters.py
@@ -1,4 +1,5 @@
 import logging
+import math
 from typing import Any
 
 from vision_agent_tools.models.utils import calculate_bbox_iou
@@ -215,7 +216,8 @@ def _filter_invalid_bboxes(
     invalid_indices = []
 
     for idx, bbox in enumerate(predictions[bboxes_key]):
-        x1, y1, x2, y2 = bbox
+        bbox_ceil = [math.ceil(num) for num in bbox]
+        x1, y1, x2, y2 = bbox_ceil
         if not (0 <= x1 < x2 <= width and 0 <= y1 < y2 <= height):
             invalid_indices.append(idx)
             _LOGGER.warning(f"Removing invalid bbox {bbox}")

--- a/vision_agent_tools/helpers/filters.py
+++ b/vision_agent_tools/helpers/filters.py
@@ -32,7 +32,10 @@ def filter_bbox_predictions(
     )
     new_preds = _remove_bboxes(new_preds, bboxes_to_remove)
     filtered_preds = _filter_invalid_bboxes(
-        predictions=new_preds, image_size=image_size
+        predictions=new_preds,
+        image_size=image_size,
+        bboxes_key=bboxes_key,
+        label_key=label_key,
     )
 
     return filtered_preds
@@ -189,13 +192,12 @@ def _contains(box_a, box_b):
 
 
 def _filter_invalid_bboxes(
-    predictions: dict[str, Any], image_size: tuple[int, int]
+    predictions: dict[str, Any],
+    image_size: tuple[int, int],
+    bboxes_key: str = "bboxes",
+    label_key: str = "labels",
 ) -> dict[str, Any]:
     """Filters out invalid bounding boxes from the given predictions.
-
-    Args:
-        predictions: A dictionary containing 'bboxes' and 'labels' keys.
-        image_size: A tuple representing the image width and height.
 
     Returns:
         A new dictionary with filtered bounding boxes and labels.
@@ -205,7 +207,7 @@ def _filter_invalid_bboxes(
 
     filtered_bboxes = []
     filtered_labels = []
-    for bbox, label in zip(predictions["bboxes"], predictions["labels"]):
+    for bbox, label in zip(predictions[bboxes_key], predictions[label_key]):
         x1, y1, x2, y2 = bbox
         if 0 <= x1 < x2 <= width and 0 <= y1 < y2 <= height:
             filtered_bboxes.append(bbox)
@@ -213,4 +215,4 @@ def _filter_invalid_bboxes(
         else:
             _LOGGER.warning(f"Removing invalid bbox {bbox}")
 
-    return {"bboxes": filtered_bboxes, "labels": filtered_labels}
+    return {bboxes_key: filtered_bboxes, label_key: filtered_labels}


### PR DESCRIPTION
This PR adds a function to return a list of invalid bounding boxes to be filtering out.
An invalid bounding box is a rectangular region that doesn't accurately enclose an object within an image. 
Specifically, a bounding box is considered invalid if:

- Negative coordinates: The coordinates defining the box are negative.
- Out-of-bounds coordinates: The box extends beyond the image dimensions.









