### PR TITLE
fix: sam2 handle empty initial bounding boxes

### DIFF
--- a/tests/models/test_florence2_sam2.py
+++ b/tests/models/test_florence2_sam2.py
@@ -1,12 +1,12 @@
 import json
 
-import pytest
 import numpy as np
+import pytest
 from PIL import Image
 
-from vision_agent_tools.shared_types import Florence2ModelName
 from vision_agent_tools.models.florence2 import Florence2Config
 from vision_agent_tools.models.florence2_sam2 import Florence2SAM2, Florence2SAM2Config
+from vision_agent_tools.shared_types import Florence2ModelName
 
 
 def test_florence2sam2_image(shared_model, assert_predictions):
@@ -95,6 +95,24 @@ def test_florence2sam2_video(shared_model, assert_predictions):
     prompt = "tomato"
 
     response = shared_model(prompt, video=test_video)
+
+    with open(
+        "tests/models/data/results/florence2sam2_video_results.json", "r"
+    ) as dest:
+        expected_results = json.load(dest)
+
+    assert_predictions(response, expected_results, img_size[::-1])
+
+
+def test_florence2sam2_video_chunk_length(shared_model, assert_predictions):
+    tomatoes_image = Image.open("tests/shared_data/images/tomatoes.jpg")
+    img_size = tomatoes_image.size
+    np_test_img = np.array(tomatoes_image, dtype=np.uint8)
+    zeros = np.zeros((img_size[1], img_size[0], 3), dtype=np.uint8)
+    test_video = np.array([np_test_img, zeros])
+    prompt = "tomato"
+
+    response = shared_model(prompt, video=test_video, chunk_length_frames=1)
 
     with open(
         "tests/models/data/results/florence2sam2_video_results.json", "r"

--- a/tests/models/test_sam2.py
+++ b/tests/models/test_sam2.py
@@ -1,9 +1,9 @@
-import pytest
 import numpy as np
+import pytest
 from PIL import Image
 
-from vision_agent_tools.shared_types import Device
 from vision_agent_tools.models.sam2 import Sam2, Sam2Config
+from vision_agent_tools.shared_types import Device, ODResponse
 
 
 def test_sam2_point_segmentation_image(shared_model, rle_decode_array):
@@ -69,6 +69,17 @@ def test_sam2_box_segmentation_image(shared_model, rle_decode_array):
         reverted_masks = rle_decode_array(annotation["mask"])
         assert reverted_masks.shape == test_image.size[::-1]
         assert annotation["logits"].shape == (256, 256)
+
+
+def test_sam2_empty_bounding_box(shared_model):
+    image_path = "tests/shared_data/images/tomatoes.jpg"
+    test_image = Image.open(image_path)
+
+    empty_bboxes = [ODResponse(labels=[], bboxes=[])]
+
+    response = shared_model(images=[test_image], bboxes=empty_bboxes)
+
+    assert response == [[]]
 
 
 def test_sam2_invalid_media(shared_model):

--- a/vision_agent_tools/models/sam2.py
+++ b/vision_agent_tools/models/sam2.py
@@ -317,7 +317,14 @@ class Sam2(BaseMLModel):
 
                     empty_frames = next_frame_idx - start_frame_idx
 
-                    video_segments.extend([[] for _ in range(empty_frames)])
+                    remaining_frames = num_frames - len(video_segments)
+
+                    if remaining_frames <= 0:
+                        break
+
+                    frames_to_add = min(empty_frames, remaining_frames)
+
+                    video_segments.extend([[] for _ in range(frames_to_add)])
                     continue
 
                 objs = self._predict_image(

--- a/vision_agent_tools/models/sam2.py
+++ b/vision_agent_tools/models/sam2.py
@@ -311,7 +311,10 @@ class Sam2(BaseMLModel):
                     else num_frames - 1
                 )
 
-                if len(bboxes[start_frame_idx].bboxes) == 0:
+                if (
+                    bboxes[start_frame_idx] is None
+                    or len(bboxes[start_frame_idx].bboxes) == 0
+                ):
                     _LOGGER.debug("Skipping predictions due to empty bounding boxes")
 
                     num_frames = next_frame_idx - start_frame_idx

--- a/vision_agent_tools/models/sam2.py
+++ b/vision_agent_tools/models/sam2.py
@@ -331,6 +331,15 @@ class Sam2(BaseMLModel):
                         box=updated_obj.bbox,
                     )
 
+                if (
+                    not inference_state["output_dict"]["cond_frame_outputs"]
+                    and not inference_state["output_dict"]["non_cond_frame_outputs"]
+                ):
+                    _LOGGER.warning(
+                        f"No points available for propagation at frame {start_frame_idx}. Skipping propagation."
+                    )
+                    continue
+
                 # Propagate the predictions on the given video segment (chunk)
                 for (
                     out_frame_idx,

--- a/vision_agent_tools/models/sam2.py
+++ b/vision_agent_tools/models/sam2.py
@@ -311,15 +311,11 @@ class Sam2(BaseMLModel):
                 ):
                     _LOGGER.debug("Skipping predictions due to empty bounding boxes")
 
-                    next_frame_idx = (
-                        start_frame_idx + chunk_length_frames
-                        if (start_frame_idx + chunk_length_frames) < num_frames
-                        else num_frames
+                    next_frame_idx = min(
+                        start_frame_idx + chunk_length_frames, num_frames
                     )
 
                     empty_frames = next_frame_idx - start_frame_idx
-
-                    _LOGGER.debug(f"Adding {empty_frames} items to the list")
 
                     video_segments.extend([[] for _ in range(empty_frames)])
                     continue

--- a/vision_agent_tools/models/sam2.py
+++ b/vision_agent_tools/models/sam2.py
@@ -317,8 +317,8 @@ class Sam2(BaseMLModel):
                 ):
                     _LOGGER.debug("Skipping predictions due to empty bounding boxes")
 
-                    num_frames = next_frame_idx - start_frame_idx
-                    video_segments.extend([[] for _ in range(num_frames)])
+                    empty_frames = next_frame_idx - start_frame_idx
+                    video_segments.extend([[] for _ in range(empty_frames)])
                     continue
 
                 objs = self._predict_image(

--- a/vision_agent_tools/models/sam2.py
+++ b/vision_agent_tools/models/sam2.py
@@ -305,19 +305,22 @@ class Sam2(BaseMLModel):
             for start_frame_idx in range(0, num_frames, chunk_length_frames):
                 self.video_model.reset_state(inference_state)
 
-                next_frame_idx = (
-                    start_frame_idx + chunk_length_frames
-                    if (start_frame_idx + chunk_length_frames) < num_frames
-                    else num_frames - 1
-                )
-
                 if (
                     bboxes[start_frame_idx] is None
                     or len(bboxes[start_frame_idx].bboxes) == 0
                 ):
                     _LOGGER.debug("Skipping predictions due to empty bounding boxes")
 
+                    next_frame_idx = (
+                        start_frame_idx + chunk_length_frames
+                        if (start_frame_idx + chunk_length_frames) < num_frames
+                        else num_frames
+                    )
+
                     empty_frames = next_frame_idx - start_frame_idx
+
+                    _LOGGER.debug(f"Adding {empty_frames} items to the list")
+
                     video_segments.extend([[] for _ in range(empty_frames)])
                     continue
 
@@ -372,10 +375,14 @@ class Sam2(BaseMLModel):
                                 id=out_obj_id,
                             )
                         )
-
+                index = (
+                    start_frame_idx + chunk_length_frames
+                    if (start_frame_idx + chunk_length_frames) < num_frames
+                    else num_frames - 1
+                )
                 # Save the last frame predictions to later update the newly found
                 # object ids
-                last_chunk_frame_pred = video_segments[next_frame_idx]
+                last_chunk_frame_pred = video_segments[index]
 
         return video_segments
 


### PR DESCRIPTION
There is a runtime error when we cannot merge segments due to sam2 not allowing empty bounding boxes.
We return `[]` empty results for frames we that do not contain any object detected.