### PR TITLE
fix: restrict florence2 prompt length

### DIFF
--- a/tests/models/florence2/test_caption_to_phrase_grounding.py
+++ b/tests/models/florence2/test_caption_to_phrase_grounding.py
@@ -1,4 +1,7 @@
 import json
+
+import pytest
+import pydantic
 from PIL import Image
 
 from vision_agent_tools.models.florence2 import Florence2, Florence2Config
@@ -127,3 +130,20 @@ def test_caption_to_phrase_grounding_image_ft(unzip_model):
             "labels": ["screw"],
         }
     ]
+
+
+def test_caption_to_phrase_grounding_prompt_length_limit(shared_large_model):
+    image_path = "tests/shared_data/images/sheep_aerial.jpg"
+    task = PromptTask.CAPTION_TO_PHRASE_GROUNDING
+    prompt = ", ".join(
+        ["1"] * 268
+    )  # this string repeats the sequence `1, ` 267 times + `1` this gives a string of length 802
+    image = Image.open(image_path)
+
+    payload = {
+        "images": [image],
+        "task": task,
+        "prompt": prompt,
+    }
+    with pytest.raises(pydantic.ValidationError):
+        shared_large_model(**payload)

--- a/vision_agent_tools/models/florence2.py
+++ b/vision_agent_tools/models/florence2.py
@@ -54,8 +54,8 @@ class Florence2Request(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     task: PromptTask = Field(description="The task to be performed on the image/video.")
-    prompt: Annotated[str | None, StringConstraints(min_length=1, max_length=800)] = (
-        Field("", description="The text input that complements the prompt task.")
+    prompt: Annotated[str | None, StringConstraints(max_length=800)] = Field(
+        "", description="The text input that complements the prompt task."
     )
     images: list[Image.Image] | None = None
     video: VideoNumpy | None = None

--- a/vision_agent_tools/models/florence2.py
+++ b/vision_agent_tools/models/florence2.py
@@ -1,12 +1,13 @@
 import logging
-from typing import Optional, Any
+from typing import Any
 
 import torch
 import numpy as np
 from PIL import Image
-from typing_extensions import Self
+from typing_extensions import Self, Annotated
 from transformers import AutoModelForCausalLM, AutoProcessor
 from pydantic import Field, BaseModel, model_validator, ConfigDict
+from pydantic.types import StringConstraints
 
 from vision_agent_tools.shared_types import (
     VideoNumpy,
@@ -53,8 +54,8 @@ class Florence2Request(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     task: PromptTask = Field(description="The task to be performed on the image/video.")
-    prompt: str | None = Field(
-        "", description="The text input that complements the prompt task."
+    prompt: Annotated[str | None, StringConstraints(min_length=1, max_length=800)] = (
+        Field("", description="The text input that complements the prompt task.")
     )
     images: list[Image.Image] | None = None
     video: VideoNumpy | None = None
@@ -109,7 +110,7 @@ class Florence2(BaseMLModel):
     def __call__(
         self,
         task: PromptTask,
-        prompt: Optional[str] = "",
+        prompt: str | None = "",
         images: list[Image.Image] | None = None,
         video: VideoNumpy | None = None,
         *,


### PR DESCRIPTION
depending on your system, passing a super long prompt to florence2 results in a `RuntimeError: CUDA error: device-side assert triggered` CUDA error. here we are limiting the length of the prompt to 800 characters but it might vary from system to system.